### PR TITLE
Alter config.sample.php - Made db_protocol empty by default

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -6,7 +6,7 @@ return array(
     'compression'   => '', // gzip, bzip2, etc
     'db_host'       => 'localhost',
     'db_port'       => '3307',
-    'db_protocol'   => 'tcp',
+    'db_protocol'   => '', // tcp, etc
     'db_user'       => 'root',
     'db_passwd'     => 'password',
     'db_names'      => array(


### PR DESCRIPTION
Having the db_protocol default set to tcp resulted in an empty .sql file on Siteground hosting. I assume the result may differ depending on the host but given that the default host is localhost and you have included an if statement around the protocol parameter in the _single_backup function in backup_db.php I suppose that an empty default might be appropriate. Alternatively/alongside this perhaps it might be worth adding a comment regarding the Protocol in the README in the appropriate place.